### PR TITLE
Prefer native app link over universal link

### DIFF
--- a/app/src/main/java/exchange/dydx/carteraExample/MainActivity.kt
+++ b/app/src/main/java/exchange/dydx/carteraExample/MainActivity.kt
@@ -19,6 +19,7 @@ import com.google.accompanist.navigation.material.ExperimentalMaterialNavigation
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
 import com.walletconnect.wcmodal.ui.walletConnectModalGraph
 import exchange.dydx.cartera.CarteraConfig
+import exchange.dydx.cartera.WalletConnectModalConfig
 import exchange.dydx.cartera.WalletConnectionType
 import exchange.dydx.cartera.walletprovider.providers.WalletConnectModalProvider
 
@@ -39,6 +40,7 @@ class MainActivity : ComponentActivity() {
             launcher = launcher,
         )
         CarteraConfig.shared?.registerWallets(context = applicationContext)
+        CarteraConfig.shared?.updateModalConfig(WalletConnectModalConfig.default)
 
         setContent {
             MyApp {

--- a/cartera/src/main/java/exchange/dydx/cartera/walletprovider/providers/WalletConnectModalProvider.kt
+++ b/cartera/src/main/java/exchange/dydx/cartera/walletprovider/providers/WalletConnectModalProvider.kt
@@ -517,7 +517,7 @@ class WalletConnectModalProvider(
             return
         }
 
-        val deeplinkPairingUri = currentSession?.metaData?.appLink ?: currentSession?.metaData?.redirect
+        val deeplinkPairingUri = currentSession?.metaData?.redirect ?: currentSession?.metaData?.appLink
         if (deeplinkPairingUri != null) {
             try {
                 val uri = Uri.parse(deeplinkPairingUri)

--- a/cartera/src/main/java/exchange/dydx/cartera/walletprovider/providers/WalletConnectUtils.kt
+++ b/cartera/src/main/java/exchange/dydx/cartera/walletprovider/providers/WalletConnectUtils.kt
@@ -1,37 +1,37 @@
 package exchange.dydx.cartera.walletprovider.providers
 
 import android.content.Context
+import android.net.Uri
 import exchange.dydx.cartera.WalletConnectionType
 import exchange.dydx.cartera.entities.Wallet
 import exchange.dydx.cartera.entities.appLink
 import exchange.dydx.cartera.entities.connections
 import exchange.dydx.cartera.entities.installed
 import exchange.dydx.cartera.entities.native
-import java.net.URL
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 object WalletConnectUtils {
-    fun createUrl(wallet: Wallet, deeplink: String?, type: WalletConnectionType, context: Context): URL? {
+    fun createUrl(wallet: Wallet, deeplink: String?, type: WalletConnectionType, context: Context): Uri? {
         if (deeplink != null) {
-            val url: URL? = if (wallet.installed(context)) {
+            val url: Uri? = if (wallet.installed(context)) {
                 build(deeplink, wallet, type)
             } else if (wallet.appLink != null) {
-                URL(wallet.appLink)
+                Uri.parse(wallet.appLink)
             } else {
-                URL(deeplink)
+                Uri.parse(deeplink)
             }
             return url
         } else {
             if (wallet.native != null && wallet.installed(context)) {
                 val deeplink = "${wallet.native}///"
-                return URL(deeplink)
+                return Uri.parse(deeplink)
             }
         }
         return null
     }
 
-    private fun build(deeplink: String, wallet: Wallet, type: WalletConnectionType): URL? {
+    private fun build(deeplink: String, wallet: Wallet, type: WalletConnectionType): Uri? {
         val config = wallet.config ?: return null
         val encoding = config.encoding
 
@@ -41,16 +41,17 @@ object WalletConnectUtils {
         val useUniversal = universal?.isNotEmpty() == true
         val useNative = native?.isNotEmpty() == true
 
-        var url: URL? = null
-        if (universal != null && useUniversal) {
-            url = createUniversallink(universal, deeplink, encoding)
-        }
-        if (native != null && useNative && url == null) {
+        var url: Uri? = null
+        if (native != null && useNative) {
             url = createDeeplink(native, deeplink, encoding)
         }
+        if (universal != null && useUniversal && url == null) {
+            url = createUniversallink(universal, deeplink, encoding)
+        }
+
         if (url == null) {
             try {
-                url = URL(deeplink)
+                url = Uri.parse(deeplink)
             } catch (e: Exception) {
                 return null
             }
@@ -58,21 +59,21 @@ object WalletConnectUtils {
         return url
     }
 
-    private fun createUniversallink(universal: String, deeplink: String, encoding: String?): URL? {
+    private fun createUniversallink(universal: String, deeplink: String, encoding: String?): Uri? {
         try {
             val encoded = encodeUri(deeplink, encoding)
             val link = "$universal/wc?uri=$encoded"
-            return URL(link)
+            return Uri.parse(link)
         } catch (e: Exception) {
             return null
         }
     }
 
-    private fun createDeeplink(native: String, deeplink: String, encoding: String?): URL? {
+    private fun createDeeplink(native: String, deeplink: String, encoding: String?): Uri? {
         try {
             val encoded = encodeUri(deeplink, encoding)
             val link = "$native//wc?uri=$encoded"
-            return URL(link)
+            return Uri.parse(link)
         } catch (e: Exception) {
             return null
         }

--- a/cartera/src/main/java/exchange/dydx/cartera/walletprovider/providers/WalletConnectV2Provider.kt
+++ b/cartera/src/main/java/exchange/dydx/cartera/walletprovider/providers/WalletConnectV2Provider.kt
@@ -3,7 +3,6 @@ package exchange.dydx.cartera.walletprovider.providers
 import android.app.Application
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.util.Log
 import com.walletconnect.android.Core
 import com.walletconnect.android.CoreClient
@@ -589,21 +588,19 @@ class WalletConnectV2Provider(
             return
         }
         // val deeplinkPairingUri = it.replace("wc:", "wc://")
-        val url = WalletConnectUtils.createUrl(
+        val uri = WalletConnectUtils.createUrl(
             wallet = request.wallet,
             deeplink = pairing.uri,
             type = WalletConnectionType.WalletConnectV2,
             context = request.context,
         )
-        val deeplinkPairingUri = url?.toURI()?.toString()
-        if (deeplinkPairingUri != null) {
+        if (uri != null) {
             try {
-                val uri = Uri.parse(deeplinkPairingUri)
                 val intent = Intent(Intent.ACTION_VIEW, uri)
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 application.startActivity(intent)
             } catch (exception: ActivityNotFoundException) {
-                Log.d(tag(this@WalletConnectV2Provider), "There is no app to handle deep linkt")
+                Log.d(tag(this@WalletConnectV2Provider), "There is no app to handle deep link")
             }
         } else {
             Log.d(tag(this@WalletConnectV2Provider), "Imvalid deeplink uri")

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,6 @@ android.nonTransitiveRClass=true
 
 LIBRARY_GROUP=dydxprotocol
 LIBRARY_ARTIFACT_ID=cartera-android
-LIBRARY_VERSION_NAME=0.1.19
+LIBRARY_VERSION_NAME=0.1.20
 
 android.enableR8.fullMode = false


### PR DESCRIPTION
Some wallet app no longer has the universal link setup correctly to redirect the user, so let's just use the native app link instead.